### PR TITLE
Force typescript version to be 2.4.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "mkdirp": "^0.5.1",
     "mocha": "^3.1.0",
     "rimraf": "^2.4.2",
-    "typescript": "^2.4.0",
+    "typescript": "2.4.2",
     "typings": "^2.0.0",
     "webpack": "^2.2.0"
   }


### PR DESCRIPTION
This should not be merged in but with new typescript updates there are type issues for a clean initial build.